### PR TITLE
Added support for RTVI protocol 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- Added support for RTVI protocol 2.0.0. `BotOutputData` now includes new fields: `willBeSpoken`, `spokenStatus`, `spokenProgress`, and `segmentId`, enabling word-level TTS progress tracking. The `spoken` field is deprecated in favour of `willBeSpoken`.
+- Added `RTVI_PROTOCOL_VERSION` constant (`"2.0.0"`).
+- The client now logs a warning when the bot is running an older RTVI protocol version than the client.
+
 # 1.1.0
 
 - Update signature of `Transport.deserializeConnectParams()` to also take the startBot `APIRequest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased
 
 - Added support for RTVI protocol 2.0.0. `BotOutputData` now includes new fields: `willBeSpoken`, `spokenStatus`, `spokenProgress`, and `segmentId`, enabling word-level TTS progress tracking. The `spoken` field is deprecated in favour of `willBeSpoken`.
-- Added `RTVI_PROTOCOL_VERSION` constant (`"2.0.0"`).
 - The client now logs a warning when the bot is running an older RTVI protocol version than the client.
 
 # 1.1.0

--- a/pipecat-client-android/src/main/java/ai/pipecat/client/PipecatClient.kt
+++ b/pipecat-client-android/src/main/java/ai/pipecat/client/PipecatClient.kt
@@ -38,7 +38,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.util.UUID
 
-internal const val RTVI_PROTOCOL_VERSION = "1.0.0"
+internal const val RTVI_PROTOCOL_VERSION = "2.0.0"
 
 /**
  * A Pipecat client. Connects to an RTVI backend and handles bidirectional audio and video
@@ -96,6 +96,12 @@ open class PipecatClient<TransportType : Transport<ConnectParams>, ConnectParams
                         this@PipecatClient.transport.setState(TransportState.Ready)
 
                         connection?.ready?.resolveOk(Unit)
+
+                        val botMajor = data.version.split(".").firstOrNull()?.toIntOrNull() ?: 0
+                        val clientMajor = RTVI_PROTOCOL_VERSION.split(".").firstOrNull()?.toIntOrNull() ?: 0
+                        if (botMajor < clientMajor) {
+                            Log.w(TAG, "Bot is running an older RTVI protocol version (${data.version}) than the client ($RTVI_PROTOCOL_VERSION). Some features may not be available.")
+                        }
 
                         callbacks.onBotReady(data)
                     }

--- a/pipecat-client-android/src/main/java/ai/pipecat/client/types/BotOutputData.kt
+++ b/pipecat-client-android/src/main/java/ai/pipecat/client/types/BotOutputData.kt
@@ -3,16 +3,52 @@ package ai.pipecat.client.types
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/** Protocol 2.0.0: Word-level TTS progress through a spoken segment. */
+@Serializable
+data class BotOutputProgressData(
+    @SerialName("accumulated_text")
+    val accumulatedText: String,
+    @SerialName("remaining_text")
+    val remainingText: String
+)
+
 /**
  * Streaming bot output tokens/chunks.
  *
- * Example:
- * {"text":"your","spoken":true,"aggregated_by":"word"}
+ * Example (Protocol 2.0.0):
+ * {"text":"your","aggregated_by":"word","will_be_spoken":true,"spoken_status":"in-progress","segment_id":1}
  */
 @Serializable
 data class BotOutputData(
     val text: String,
-    val spoken: Boolean,
     @SerialName("aggregated_by")
-    val aggregatedBy: String
-)
+    val aggregatedBy: String,
+
+    /** Deprecated (Protocol 1.4.x). Use [willBeSpoken] instead. */
+    @Deprecated("Use willBeSpoken instead. This field will be removed in a future version.")
+    val spoken: Boolean? = null,
+
+    /** Protocol 2.0.0: Whether this text will be spoken by TTS. */
+    @SerialName("will_be_spoken")
+    val willBeSpoken: Boolean? = null,
+
+    /** Protocol 2.0.0: Current lifecycle stage of the spoken segment. */
+    @SerialName("spoken_status")
+    val spokenStatus: SpokenStatus? = null,
+
+    /** Protocol 2.0.0: Word-level progress through the spoken segment. */
+    @SerialName("spoken_progress")
+    val spokenProgress: BotOutputProgressData? = null,
+
+    /** Protocol 2.0.0: Correlates progress events for the same spoken segment. */
+    @SerialName("segment_id")
+    val segmentId: Int? = null
+) {
+    /** Protocol 2.0.0: Lifecycle stage of a spoken segment. */
+    @Serializable
+    enum class SpokenStatus {
+        @SerialName("new") New,
+        @SerialName("in-progress") InProgress,
+        @SerialName("completed") Completed
+    }
+}


### PR DESCRIPTION
  BotOutputData.kt
  - spoken: Boolean → Boolean? = null (deprecated, now optional to match Protocol 2.0.0 where server sends null)
  - New BotOutputProgressData data class with accumulatedText / remainingText
  - New BotOutputData.SpokenStatus enum: New, InProgress ("in-progress"), Completed
  - Added willBeSpoken, spokenStatus, spokenProgress, segmentId: Int? — all optional, all defaulting to null

  PipecatClient.kt
  - RTVI_PROTOCOL_VERSION bumped "1.0.0" → "2.0.0" and made public (was internal)
  - BotReady handler now logs a warning when the server's major version is behind the client's